### PR TITLE
Changing `dashboard-activity-feed.${channel}`

### DIFF
--- a/utilities/seTwitchRewardsPubSub.js
+++ b/utilities/seTwitchRewardsPubSub.js
@@ -15,7 +15,7 @@ This program is free software: you can redistribute it and/or modify
 */
 class TwitchRewardsPubSub {
   constructor(channel) {
-    this.topic = `dashboard-activity-feed.${channel}`;
+    this.topic = `community-points-channel-v1.${channel}`;
   };
 
   connect() {


### PR DESCRIPTION
The topic `dashboard-activity-feed.${channel}` in utilities/seTwitchRewardsPubSub.js does not exist anymore. Instead you can use `community-points-channel-v1.${channel}`.